### PR TITLE
105: Padronização do tamanho das imagens e dos títulos dos cards.

### DIFF
--- a/config-exemple.php
+++ b/config-exemple.php
@@ -12,6 +12,8 @@
     $url = "https://gateway.marvel.com:443/v1/public/";
     $apiKey = "ts={$time}&apikey={$plublickey}&hash={$hash}";
 
+    $imageSizeUrl = "/portrait_incredible.";
+
     echo $url;
 
 ?>

--- a/css/style.css
+++ b/css/style.css
@@ -7,14 +7,18 @@
     border-radius: 0;
 }
 .card .titulo {
-    height: 5 rem;
+    height: 5rem;
 }
 .carousel-inner {
     width: auto;
-    height: 400px;
+    height: 500px;
     overflow: hidden;
 }
 
 .carousel-inner::-webkit-scrollbar {
     display: none;
+}
+.carousel-inner .img-fluid {
+    width: 100%;
+    height: auto;
 }

--- a/paginas/character.php
+++ b/paginas/character.php
@@ -16,7 +16,7 @@ if (empty($id)) {
 
     $path = $character->thumbnail->path;
     $extension = $character->thumbnail->extension;
-    $image = $path . "/portrait_incredible." . $extension;
+    $image = $path . $imageSizeUrl . $extension;
     $name = $character->name;
     $description = $character->description;
 
@@ -45,7 +45,7 @@ if (empty($id)) {
             $title = $comics->title;
             $path = $comics->thumbnail->path;
             $extension = $comics->thumbnail->extension;
-            $image = $path ."/portrait_incredible.". $extension;
+            $image = $path .$imageSizeUrl. $extension;
         ?>
             <div class="col-12 col-md-3">
                 <div class="card">
@@ -77,7 +77,7 @@ if (empty($id)) {
             $title = $series->title;
             $path = $series->thumbnail->path;
             $extension = $series->thumbnail->extension;
-            $image = $path ."/portrait_incredible.". $extension;
+            $image = $path .$imageSizeUrl. $extension;
         ?>
             <div class="col-12 col-md-3">
                 <div class="card">
@@ -109,7 +109,7 @@ if (empty($id)) {
             $title = $stories->title;
             $path = $stories->thumbnail->path ?? null;
             $extension = $stories->thumbnail->extension ?? null;
-            $image = $path ."/portrait_incredible.". $extension;
+            $image = $path .$imageSizeUrl. $extension;
         ?>
             <div class="col-12 col-md-3">
                 <div class="card">
@@ -141,7 +141,7 @@ if (empty($id)) {
             $title = $events->title;
             $path = $events->thumbnail->path;
             $extension = $events->thumbnail->extension;
-            $image = $path ."/portrait_incredible.". $extension;
+            $image = $path .$imageSizeUrl. $extension;
         ?>
             <div class="col-12 col-md-3">
                 <div class="card">

--- a/paginas/character.php
+++ b/paginas/character.php
@@ -52,7 +52,9 @@ if (empty($id)) {
                     <img src="<?= $image ?>" alt="<?= $title ?>">
                     <div class="card-body text-center">
                         <p class="titulo">
-                            <strong><?= $title ?></strong>
+                            <strong>
+                                <?= $title ?>
+                            </strong>
                         </p>
                         <p>
                             <a href="comic/<?= $id ?>" class="btn btn-warning">See more</a>
@@ -81,10 +83,12 @@ if (empty($id)) {
         ?>
             <div class="col-12 col-md-3">
                 <div class="card">
-                    <img src="<?= $image ?>" alt="<?= $title ?>" class="card-img-top">
+                    <img src="<?= $image ?>" alt="<?= $title ?>">
                     <div class="card-body text-center">
                         <p class="titulo">
-                            <strong><?= $title ?></strong>
+                            <strong>
+                                <?= $title ?>
+                            </strong>
                         </p>
                         <p>
                             <a href="serie/<?= $id ?>" class="btn btn-warning">See more</a>
@@ -113,10 +117,12 @@ if (empty($id)) {
         ?>
             <div class="col-12 col-md-3">
                 <div class="card">
-                    <img src="<?= $image ?>" alt="<?= $title ?>" class="card-img-top">
+                    <img src="<?= $image ?>" alt="<?= $title ?>">
                     <div class="card-body text-center">
                         <p class="titulo">
-                            <strong><?= $title ?></strong>
+                            <strong>
+                                <?= $title ?>
+                            </strong>
                         </p>
                         <p>
                             <a href="storie/<?= $id ?>" class="btn btn-warning">See more</a>
@@ -145,10 +151,12 @@ if (empty($id)) {
         ?>
             <div class="col-12 col-md-3">
                 <div class="card">
-                    <img src="<?= $image ?>" alt="<?= $title ?>" class="card-img-top">
+                    <img src="<?= $image ?>" alt="<?= $title ?>">
                     <div class="text-center">
                         <p class="titulo">
-                            <strong><?= $title ?></strong>
+                            <strong>
+                                <?= $title ?>
+                            </strong>
                         </p>
                         <p>
                             <a href="event/<?= $id ?>" class="btn btn-warning">See more</a>

--- a/paginas/character.php
+++ b/paginas/character.php
@@ -16,7 +16,7 @@ if (empty($id)) {
 
     $path = $character->thumbnail->path;
     $extension = $character->thumbnail->extension;
-    $image = $path . "/portrait_uncanny." . $extension;
+    $image = $path . "/portrait_incredible." . $extension;
     $name = $character->name;
     $description = $character->description;
 
@@ -45,13 +45,15 @@ if (empty($id)) {
             $title = $comics->title;
             $path = $comics->thumbnail->path;
             $extension = $comics->thumbnail->extension;
-            $image = $path . "." . $extension;
+            $image = $path ."/portrait_incredible.". $extension;
         ?>
             <div class="col-12 col-md-3">
                 <div class="card">
+                    <img src="<?= $image ?>" alt="<?= $title ?>">
                     <div class="card-body text-center">
-                        <img src="<?= $image ?>" alt="<?= $title ?>" class="card-img-top">
-                        <p class="card-title"><?= $title ?></p>
+                        <p class="titulo">
+                            <strong><?= $title ?></strong>
+                        </p>
                         <p>
                             <a href="comic/<?= $id ?>" class="btn btn-warning">See more</a>
                         </p>
@@ -75,13 +77,15 @@ if (empty($id)) {
             $title = $series->title;
             $path = $series->thumbnail->path;
             $extension = $series->thumbnail->extension;
-            $image = $path . "." . $extension;
+            $image = $path ."/portrait_incredible.". $extension;
         ?>
             <div class="col-12 col-md-3">
                 <div class="card">
+                    <img src="<?= $image ?>" alt="<?= $title ?>" class="card-img-top">
                     <div class="card-body text-center">
-                        <img src="<?= $image ?>" alt="<?= $title ?>" class="card-img-top">
-                        <p class="card-title"><?= $title ?></p>
+                        <p class="titulo">
+                            <strong><?= $title ?></strong>
+                        </p>
                         <p>
                             <a href="serie/<?= $id ?>" class="btn btn-warning">See more</a>
                         </p>
@@ -105,13 +109,15 @@ if (empty($id)) {
             $title = $stories->title;
             $path = $stories->thumbnail->path ?? null;
             $extension = $stories->thumbnail->extension ?? null;
-            $image = $path . "." . $extension;
+            $image = $path ."/portrait_incredible.". $extension;
         ?>
             <div class="col-12 col-md-3">
                 <div class="card">
+                    <img src="<?= $image ?>" alt="<?= $title ?>" class="card-img-top">
                     <div class="card-body text-center">
-                        <img src="<?= $image ?>" alt="<?= $title ?>" class="card-img-top">
-                        <p class="card-title"><?= $title ?></p>
+                        <p class="titulo">
+                            <strong><?= $title ?></strong>
+                        </p>
                         <p>
                             <a href="storie/<?= $id ?>" class="btn btn-warning">See more</a>
                         </p>
@@ -135,13 +141,15 @@ if (empty($id)) {
             $title = $events->title;
             $path = $events->thumbnail->path;
             $extension = $events->thumbnail->extension;
-            $image = $path . "." . $extension;
+            $image = $path ."/portrait_incredible.". $extension;
         ?>
             <div class="col-12 col-md-3">
                 <div class="card">
-                    <div class="card-body text-center">
-                        <img src="<?= $image ?>" alt="<?= $title ?>" class="card-img-top">
-                        <p class="card-title"><?= $title ?></p>
+                    <img src="<?= $image ?>" alt="<?= $title ?>" class="card-img-top">
+                    <div class="text-center">
+                        <p class="titulo">
+                            <strong><?= $title ?></strong>
+                        </p>
                         <p>
                             <a href="event/<?= $id ?>" class="btn btn-warning">See more</a>
                         </p>

--- a/paginas/characters.php
+++ b/paginas/characters.php
@@ -10,7 +10,7 @@
     foreach ($dados->data->results as $comics) {
         $path = $comics->thumbnail->path;
         $extension = $comics->thumbnail->extension;
-        $image = $path .".". $extension;
+        $image = $path ."/portrait_incredible.". $extension;
         $name = $comics->name;
         $id = $comics->id;
 
@@ -19,13 +19,16 @@
             <div class="card">
                 <img src="<?= $image ?>" alt="<?= $name ?>">
                 <div class="card-body text-center">
-                    <p class="titulo"><strong><?= $name?></strong></p>
+                    <p class="titulo">
+                        <strong>
+                            <?= $name ?>
+                        </strong>
+                    </p>
                     <p>
-                        <a href="character/<?= $id?>" class="btn btn-warning">Ver detalhes</a>
+                        <a href="character/<?= $id ?>" class="btn btn-warning">See more</a>
                     </p>
                 </div>
             </div>
-
         </div>
     <?php
     }

--- a/paginas/characters.php
+++ b/paginas/characters.php
@@ -10,7 +10,7 @@
     foreach ($dados->data->results as $comics) {
         $path = $comics->thumbnail->path;
         $extension = $comics->thumbnail->extension;
-        $image = $path ."/portrait_incredible.". $extension;
+        $image = $path .$imageSizeUrl. $extension;
         $name = $comics->name;
         $id = $comics->id;
 

--- a/paginas/comic.php
+++ b/paginas/comic.php
@@ -18,7 +18,7 @@ if (empty($id)) {
     $description = $comic->description;
     $path = $comic->thumbnail->path;
     $extension = $comic->thumbnail->extension;
-    $image = $path . "/portrait_uncanny." . $extension;
+    $image = $path . "/portrait_incredible." . $extension;
 ?>
     <h1 class="text-center my-5">Comic</h1>
     <div class="card">
@@ -64,21 +64,23 @@ if (empty($id)) {
                                 foreach ($dados->data->results as $characters) {
                                     $path = $characters->thumbnail->path;
                                     $extension = $characters->thumbnail->extension;
-                                    $image = $path . "/portrait_uncanny." . $extension;
+                                    $image = $path ."/portrait_incredible.". $extension;
                                     $name = $characters->name;
                                     $id = $characters->id;
                             ?>
                                 <div class="col-12 col-md-3 px-1">
-                                    <div class="card card-body h-100 text-center">
-                                        <img class="img-fluid w-100 h-75" src="<?= $image ?>" alt="<?= $name ?>">
-                                        <p class="titulo">
-                                            <strong>
-                                                <?= $name ?>
-                                            </strong>
-                                        </p>
-                                        <p>
-                                            <a href="character/<?= $id ?>" class="btn btn-warning"> See more</a>
-                                        </p>
+                                    <div class="card h-100">
+                                        <img class="img-fluid" src="<?= $image ?>" alt="<?= $name ?>">
+                                        <div class="card-body text-center">
+                                            <p class="titulo">
+                                                <strong>
+                                                    <?= $name ?>
+                                                </strong>
+                                            </p>
+                                            <p>
+                                                <a href="character/<?= $id ?>" class="btn btn-warning"> See more</a>
+                                            </p>
+                                        </div>
                                     </div>
                                 </div>
                             <?php
@@ -110,21 +112,23 @@ if (empty($id)) {
                 foreach ($dados->data->results as $creators) {
                     $path = $creators->thumbnail->path;
                     $extension = $creators->thumbnail->extension;
-                    $image = $path . "/portrait_uncanny." . $extension;
+                    $image = $path ."/portrait_incredible.". $extension;
                     $id = $creators->id;
                     $fullName = $creators->fullName;
             ?>
                     <div class="col-12 col-md-3">
-                        <div class="card text-center">
-                            <img src="<?= $image?>" alt="<?= $fullName?>" class="w-100">
-                            <p class="titulo">
-                                <strong>
-                                    <?=$fullName?>
-                                </strong>
-                                <p>
-                                    <a href="creators/<?=$id?>" class="btn btn-warning"> See More</a>
+                        <div class="card h-100">
+                            <img src="<?= $image ?>" alt="<?=  $fullName ?>">
+                            <div class="card-body text-center">
+                                <p class="titulo">
+                                    <strong>
+                                        <?= $fullName ?>
+                                    </strong>
                                 </p>
-                            </p>
+                                <p>
+                                    <a href="creators/<?= $id ?>" class="btn btn-warning"> See more</a>
+                                </p>
+                            </div>
                         </div>
                     </div>
             <?php

--- a/paginas/comic.php
+++ b/paginas/comic.php
@@ -18,7 +18,7 @@ if (empty($id)) {
     $description = $comic->description;
     $path = $comic->thumbnail->path;
     $extension = $comic->thumbnail->extension;
-    $image = $path . "/portrait_incredible." . $extension;
+    $image = $path . $imageSizeUrl . $extension;
 ?>
     <h1 class="text-center my-5">Comic</h1>
     <div class="card">
@@ -64,7 +64,7 @@ if (empty($id)) {
                                 foreach ($dados->data->results as $characters) {
                                     $path = $characters->thumbnail->path;
                                     $extension = $characters->thumbnail->extension;
-                                    $image = $path ."/portrait_incredible.". $extension;
+                                    $image = $path .$imageSizeUrl. $extension;
                                     $name = $characters->name;
                                     $id = $characters->id;
                             ?>
@@ -112,7 +112,7 @@ if (empty($id)) {
                 foreach ($dados->data->results as $creators) {
                     $path = $creators->thumbnail->path;
                     $extension = $creators->thumbnail->extension;
-                    $image = $path ."/portrait_incredible.". $extension;
+                    $image = $path .$imageSizeUrl. $extension;
                     $id = $creators->id;
                     $fullName = $creators->fullName;
             ?>

--- a/paginas/comics.php
+++ b/paginas/comics.php
@@ -10,7 +10,7 @@
     foreach ($dados->data->results as $comics) {
         $path = $comics->thumbnail->path;
         $extension = $comics->thumbnail->extension;
-        $image = $path .".". $extension;
+        $image = $path ."/portrait_incredible.". $extension;
         $title = $comics->title;
         $id = $comics->id;
 
@@ -19,9 +19,13 @@
             <div class="card">
                 <img src="<?= $image ?>" alt="<?= $title ?>">
                 <div class="card-body text-center">
-                    <p class="titulo"><strong><?= $title?></strong></p>
+                    <p class="titulo">
+                        <strong>
+                            <?= $title ?>
+                        </strong>
+                    </p>
                     <p>
-                        <a href="comic/<?= $id?>" class="btn btn-warning">Ver detalhes</a>
+                        <a href="comic/<?= $id?>" class="btn btn-warning">See more</a>
                     </p>
                 </div>
             </div>

--- a/paginas/comics.php
+++ b/paginas/comics.php
@@ -10,7 +10,7 @@
     foreach ($dados->data->results as $comics) {
         $path = $comics->thumbnail->path;
         $extension = $comics->thumbnail->extension;
-        $image = $path ."/portrait_incredible.". $extension;
+        $image = $path .$imageSizeUrl. $extension;
         $title = $comics->title;
         $id = $comics->id;
 

--- a/paginas/creator.php
+++ b/paginas/creator.php
@@ -16,7 +16,7 @@ if (empty($id)) {
 
     $path = $creator->thumbnail->path;
     $extension = $creator->thumbnail->extension;
-    $image = $path ."/portrait_incredible.". $extension;
+    $image = $path .$imageSizeUrl. $extension;
     $name = $creator->fullName;
 
 ?>
@@ -45,7 +45,7 @@ if (empty($id)) {
             $title = $comics->title;
             $path = $comics->thumbnail->path;
             $extension = $comics->thumbnail->extension;
-            $image = $path . "/portrait_incredible." . $extension;
+            $image = $path . $imageSizeUrl . $extension;
         ?>
             <div class="col-12 col-md-3">
                 <div class="card">
@@ -83,7 +83,7 @@ if (empty($id)) {
                 $title = $series->title;
                 $path = $series->thumbnail->path;
                 $extension = $series->thumbnail->extension;
-                $image = $path ."/portrait_incredible.". $extension;
+                $image = $path .$imageSizeUrl. $extension;
             ?>
                 <div class="col-12 col-md-3">
                     <div class="card">
@@ -121,7 +121,7 @@ if (empty($id)) {
                 $title = $stories->title;
                 $path = $stories->thumbnail->path ?? null;
                 $extension = $stories->thumbnail->extension ?? null;
-                $image = $path ."/portrait_incredible.". $extension;
+                $image = $path .$imageSizeUrl. $extension;
         ?>
                 <div class="col-12 col-md-3">
                     <div class="card">
@@ -159,7 +159,7 @@ if (empty($id)) {
             $title = $events->title;
             $path = $events->thumbnail->path;
             $extension = $events->thumbnail->extension;
-            $image = $path ."/portrait_incredible.". $extension;
+            $image = $path .$imageSizeUrl. $extension;
         ?>
             <div class="col-12 col-md-3">
                 <div class="card">

--- a/paginas/creator.php
+++ b/paginas/creator.php
@@ -16,7 +16,7 @@ if (empty($id)) {
 
     $path = $creator->thumbnail->path;
     $extension = $creator->thumbnail->extension;
-    $image = $path . "/portrait_uncanny." . $extension;
+    $image = $path ."/portrait_incredible.". $extension;
     $name = $creator->fullName;
 
 ?>
@@ -45,13 +45,17 @@ if (empty($id)) {
             $title = $comics->title;
             $path = $comics->thumbnail->path;
             $extension = $comics->thumbnail->extension;
-            $image = $path . "." . $extension;
+            $image = $path . "/portrait_incredible." . $extension;
         ?>
             <div class="col-12 col-md-3">
                 <div class="card">
+                    <img src="<?= $image ?>" alt="<?= $title ?>">
                     <div class="card-body text-center">
-                        <img src="<?= $image ?>" alt="<?= $title ?>" class="card-img-top w-100 h-75">
-                        <p class="card-title"><?= $title ?></p>
+                        <p class="titulo">
+                            <strong>
+                                <?= $title ?>
+                            </strong>
+                        </p>
                         <p>
                             <a href="comic/<?= $id ?>" class="btn btn-warning">See more</a>
                         </p>
@@ -79,13 +83,17 @@ if (empty($id)) {
                 $title = $series->title;
                 $path = $series->thumbnail->path;
                 $extension = $series->thumbnail->extension;
-                $image = $path . "." . $extension;
+                $image = $path ."/portrait_incredible.". $extension;
             ?>
                 <div class="col-12 col-md-3">
                     <div class="card">
+                        <img src="<?= $image ?>" alt="<?= $title ?>">
                         <div class="card-body text-center">
-                            <img src="<?= $image ?>" alt="<?= $title ?>" class="card-img-top w-100 h-75">
-                            <p class="card-title"><?= $title ?></p>
+                            <p class="titulo">
+                                <strong>
+                                    <?= $title ?>
+                                </strong>
+                            </p>
                             <p>
                                 <a href="serie/<?= $id ?>" class="btn btn-warning">See more</a>
                             </p>
@@ -108,27 +116,31 @@ if (empty($id)) {
         <h2 class="text-center">Stories</h2>
         <div class="row text-center">
         <?php
-        foreach ($dados->data->results as $stories) {
-            $id = $stories->id;
-            $title = $stories->title;
-            $path = $stories->thumbnail->path ?? null;
-            $extension = $stories->thumbnail->extension ?? null;
-            $image = $path . "." . $extension;
+            foreach ($dados->data->results as $stories) {
+                $id = $stories->id;
+                $title = $stories->title;
+                $path = $stories->thumbnail->path ?? null;
+                $extension = $stories->thumbnail->extension ?? null;
+                $image = $path ."/portrait_incredible.". $extension;
         ?>
-            <div class="col-12 col-md-3">
-                <div class="card">
-                    <div class="card-body text-center">
-                        <img src="<?= $image ?>" alt="<?= $title ?>" class="card-img-top w-100 h-75">
-                        <p class="card-title"><?= $title ?></p>
-                        <p>
-                            <a href="storie/<?= $id ?>" class="btn btn-warning">See more</a>
-                        </p>
+                <div class="col-12 col-md-3">
+                    <div class="card">
+                        <img src="<?= $image ?>" alt="<?= $title ?>">
+                        <div class="card-body text-center">
+                            <p class="titulo">
+                                <strong>
+                                    <?= $title ?>
+                                </strong>
+                            </p>
+                            <p>
+                                <a href="storie/<?= $id ?>" class="btn btn-warning">See more</a>
+                            </p>
+                        </div>
                     </div>
                 </div>
-            </div>
-        <?php
-        }
-        ?>
+            <?php
+            }
+            ?>
         </div>
         <?php
     }
@@ -147,13 +159,17 @@ if (empty($id)) {
             $title = $events->title;
             $path = $events->thumbnail->path;
             $extension = $events->thumbnail->extension;
-            $image = $path . "." . $extension;
+            $image = $path ."/portrait_incredible.". $extension;
         ?>
             <div class="col-12 col-md-3">
                 <div class="card">
+                    <img src="<?= $image ?>" alt="<?= $title ?>">
                     <div class="card-body text-center">
-                        <img src="<?= $image ?>" alt="<?= $title ?>" class="card-img-top w-100 h-75">
-                        <p class="card-title"><?= $title ?></p>
+                        <p class="titulo">
+                            <strong>
+                                <?= $title ?>
+                            </strong>
+                        </p>
                         <p>
                             <a href="event/<?= $id ?>" class="btn btn-warning">See more</a>
                         </p>

--- a/paginas/creators.php
+++ b/paginas/creators.php
@@ -10,7 +10,7 @@
     foreach ($dados->data->results as $creator) {
         $path = $creator->thumbnail->path;
         $extension = $creator->thumbnail->extension;
-        $image = $path .".". $extension;
+        $image = $path ."/portrait_incredible.". $extension;
         $name = $creator->fullName;
         $id = $creator->id;
 
@@ -19,9 +19,13 @@
             <div class="card">
                 <img src="<?= $image ?>" alt="<?= $name ?>">
                 <div class="card-body text-center">
-                    <p class="titulo"><strong><?= $name?></strong></p>
+                    <p class="titulo">
+                        <strong>
+                            <?= $name ?>
+                        </strong>
+                    </p>
                     <p>
-                        <a href="creator/<?= $id?>" class="btn btn-warning">Ver detalhes</a>
+                        <a href="creator/<?= $id ?>" class="btn btn-warning">See more</a>
                     </p>
                 </div>
             </div>

--- a/paginas/creators.php
+++ b/paginas/creators.php
@@ -10,7 +10,7 @@
     foreach ($dados->data->results as $creator) {
         $path = $creator->thumbnail->path;
         $extension = $creator->thumbnail->extension;
-        $image = $path ."/portrait_incredible.". $extension;
+        $image = $path .$imageSizeUrl. $extension;
         $name = $creator->fullName;
         $id = $creator->id;
 

--- a/paginas/event.php
+++ b/paginas/event.php
@@ -14,7 +14,7 @@
         $description = $comic->description;
         $path = $comic->thumbnail->path;
         $extension = $comic->thumbnail->extension;
-        $image = $path ."/portrait_incredible.". $extension;
+        $image = $path .$imageSizeUrl. $extension;
 ?>
     <h1 class="text-center my-5">Event</h1>
     <div class="card">
@@ -57,7 +57,7 @@
                 foreach ($dados->data->results as $characters) {
                     $path = $characters->thumbnail->path;
                     $extension = $characters->thumbnail->extension;
-                    $image = $path ."/portrait_incredible.". $extension;
+                    $image = $path .$imageSizeUrl. $extension;
                     $id = $characters->id;
                     $name = $characters->name;
             ?>
@@ -96,7 +96,7 @@
             foreach ($dados->data->results as $creators) {
                 $path = $creators->thumbnail->path;
                 $extension = $creators->thumbnail->extension;
-                $image = $path ."/portrait_incredible.". $extension;
+                $image = $path .$imageSizeUrl. $extension;
                 $id = $creators->id;
                 $fullName = $creators->fullName;
         ?>
@@ -134,7 +134,7 @@
             foreach ($dados->data->results as $comics) {
                 $path = $comics->thumbnail->path;
                 $extension = $comics->thumbnail->extension;
-                $image = $path ."/portrait_incredible.". $extension;
+                $image = $path .$imageSizeUrl. $extension;
                 $title = $comics->title;
                 $id = $comics->id;
         ?>
@@ -174,7 +174,7 @@
                 $title = $series->title;
                 $path = $series->thumbnail->path;
                 $extension = $series->thumbnail->extension;
-                $image = $path ."/portrait_incredible.". $extension;
+                $image = $path .$imageSizeUrl. $extension;
         ?>
                 <div class="col-12 col-md-3">
                     <div class="card">
@@ -212,7 +212,7 @@
                 $title = $stories->title;
                 $path = $stories->thumbnail->path ?? null;
                 $extension = $stories->thumbnail->extension ?? null;
-                $image = $path ."/portrait_incredible.". $extension;
+                $image = $path .$imageSizeUrl. $extension;
         ?>
                 <div class="col-12 col-md-3">
                     <div class="card">

--- a/paginas/event.php
+++ b/paginas/event.php
@@ -14,7 +14,7 @@
         $description = $comic->description;
         $path = $comic->thumbnail->path;
         $extension = $comic->thumbnail->extension;
-        $image = $path . "/portrait_uncanny." . $extension;
+        $image = $path ."/portrait_incredible.". $extension;
 ?>
     <h1 class="text-center my-5">Event</h1>
     <div class="card">
@@ -57,21 +57,23 @@
                 foreach ($dados->data->results as $characters) {
                     $path = $characters->thumbnail->path;
                     $extension = $characters->thumbnail->extension;
-                    $image = $path . "." . $extension;
+                    $image = $path ."/portrait_incredible.". $extension;
                     $id = $characters->id;
                     $name = $characters->name;
             ?>
                     <div class="col-12 col-md-3">
-                        <div class="card text-center">
-                            <img src="<?= $image?>" alt="<?= $name?>">
-                            <p class="titulo">
-                                <strong>
-                                    <?=$name?>
-                                </strong>
-                                <p>
-                                    <a href="character/<?=$id?>" class="btn btn-warning"> See More</a>
+                        <div class="card">
+                            <img src="<?= $image ?>" alt="<?= $name ?>">
+                            <div class="card-body text-center">
+                                <p class="titulo">
+                                    <strong>
+                                        <?= $name ?>
+                                    </strong>
                                 </p>
-                            </p>
+                                <p>
+                                    <a href="character/<?= $id ?>" class="btn btn-warning"> See more</a>
+                                </p>
+                            </div>
                         </div>
                     </div>
             <?php
@@ -94,17 +96,23 @@
             foreach ($dados->data->results as $creators) {
                 $path = $creators->thumbnail->path;
                 $extension = $creators->thumbnail->extension;
-                $image = $path . "." . $extension;
+                $image = $path ."/portrait_incredible.". $extension;
                 $id = $creators->id;
                 $fullName = $creators->fullName;
         ?>
                 <div class="col-12 col-md-3">
-                    <div class="card text-center">
-                        <img src="<?= $image?>" alt="<?= $fullName?>">
-                        <p class="titulo">
-                            <strong><?=$fullName?></strong>
-                            <p><a href="creator/<?=$id?>" class="btn btn-warning"> See More</a></p>
-                        </p>
+                    <div class="card">
+                        <img src="<?= $image ?>" alt="<?= $fullName ?>">
+                        <div class="card-body text-center">
+                            <p class="titulo">
+                                <strong>
+                                    <?= $fullName ?>
+                                </strong>
+                            </p>
+                            <p>
+                                <a href="creator/<?= $id ?>" class="btn btn-warning"> See more</a>
+                            </p>
+                        </div>
                     </div>
                 </div>
         <?php
@@ -126,7 +134,7 @@
             foreach ($dados->data->results as $comics) {
                 $path = $comics->thumbnail->path;
                 $extension = $comics->thumbnail->extension;
-                $image = $path .".". $extension;
+                $image = $path ."/portrait_incredible.". $extension;
                 $title = $comics->title;
                 $id = $comics->id;
         ?>
@@ -134,9 +142,13 @@
                     <div class="card">
                         <img src="<?= $image ?>" alt="<?= $title ?>">
                         <div class="card-body text-center">
-                            <p class="titulo"><strong><?= $title?></strong></p>
+                            <p class="titulo">
+                                <strong>
+                                    <?= $title ?>
+                                </strong>
+                            </p>
                             <p>
-                                <a href="comic/<?= $id?>" class="btn btn-warning">See more</a>
+                                <a href="comic/<?= $id ?>" class="btn btn-warning">See more</a>
                             </p>
                         </div>
                     </div>
@@ -162,13 +174,17 @@
                 $title = $series->title;
                 $path = $series->thumbnail->path;
                 $extension = $series->thumbnail->extension;
-                $image = $path . "." . $extension;
+                $image = $path ."/portrait_incredible.". $extension;
         ?>
                 <div class="col-12 col-md-3">
                     <div class="card">
+                        <img src="<?= $image ?>" alt="<?= $title ?>">
                         <div class="card-body text-center">
-                            <img src="<?= $image ?>" alt="<?= $title ?>" class="card-img-top">
-                            <p class="card-title"><?= $title ?></p>
+                            <p class="titulo">
+                                <strong>
+                                    <?= $title ?>
+                                </strong>
+                            </p>
                             <p>
                                 <a href="serie/<?= $id ?>" class="btn btn-warning">See more</a>
                             </p>
@@ -196,13 +212,17 @@
                 $title = $stories->title;
                 $path = $stories->thumbnail->path ?? null;
                 $extension = $stories->thumbnail->extension ?? null;
-                $image = $path . "." . $extension;
+                $image = $path ."/portrait_incredible.". $extension;
         ?>
                 <div class="col-12 col-md-3">
                     <div class="card">
+                        <img src="<?= $image ?>" alt="<?= $title ?>">
                         <div class="card-body text-center">
-                            <img src="<?= $image ?>" alt="<?= $title ?>" class="card-img-top">
-                            <p class="card-title"><?= $title ?></p>
+                            <p class="titulo">
+                                <strong>
+                                    <?= $title ?>
+                                </strong>
+                            </p>
                             <p>
                                 <a href="storie/<?= $id ?>" class="btn btn-warning">See more</a>
                             </p>

--- a/paginas/events.php
+++ b/paginas/events.php
@@ -1,5 +1,5 @@
 <h1 class="text-center">
-    Comics
+    Events
 </h1>
 <div class="row">
         <?php
@@ -10,7 +10,7 @@
         foreach ($dados->data->results as $comics) {
             $path = $comics->thumbnail->path;
             $extension = $comics->thumbnail->extension;
-            $image = $path .".". $extension;
+            $image = $path ."/portrait_incredible.". $extension;
             $title = $comics->title;
             $id = $comics->id;
     ?>
@@ -18,9 +18,13 @@
         <div class="card">
             <img src="<?= $image ?>" alt="<?= $title ?>">
             <div class="card-body text-center">
-                <p class="titulo"><strong><?= $title?></strong></p>
+                <p class="titulo">
+                    <strong>
+                        <?= $title ?>
+                    </strong>
+                </p>
                 <p>
-                    <a href="event/<?= $id?>" class="btn btn-warning">See more</a>
+                    <a href="event/<?= $id ?>" class="btn btn-warning">See more</a>
                 </p>
             </div>
         </div>

--- a/paginas/events.php
+++ b/paginas/events.php
@@ -10,7 +10,7 @@
         foreach ($dados->data->results as $comics) {
             $path = $comics->thumbnail->path;
             $extension = $comics->thumbnail->extension;
-            $image = $path ."/portrait_incredible.". $extension;
+            $image = $path .$imageSizeUrl. $extension;
             $title = $comics->title;
             $id = $comics->id;
     ?>

--- a/paginas/serie.php
+++ b/paginas/serie.php
@@ -14,7 +14,7 @@
         $title = $serie->title;
         $description = $serie->description;
         $extension = $serie->thumbnail->extension;
-        $image = $path . "/portrait_uncanny." . $extension;
+        $image = $path ."/portrait_incredible.". $extension;
 
 ?>
     <h1 class="text-center my-5">Serie</h1>
@@ -58,19 +58,23 @@
                 foreach ($dados->data->results as $characters) {
                     $path = $characters->thumbnail->path;
                     $extension = $characters->thumbnail->extension;
-                    $image = $path . "." . $extension;
+                    $image = $path ."/portrait_incredible.". $extension;
                     $name = $characters->name;
                     $id = $characters->id;
             ?>
                     <div class="col-12 col-md-3">
-                        <div class="card text-center">
+                        <div class="card">
                             <img src="<?= $image ?>" alt="<?= $name ?>">
-                            <p class="titulo">
-                                <strong><?= $name ?></strong>
-                            </p>
-                            <p>
-                                <a href="character/<?= $id ?>" class="btn btn-warning"> See more</a>
-                            </p>
+                            <div class="card-body text-center">
+                                <p class="titulo">
+                                    <strong>
+                                        <?= $name ?>
+                                    </strong>
+                                </p>
+                                <p>
+                                    <a href="character/<?= $id ?>" class="btn btn-warning"> See more</a>
+                                </p>
+                            </div>
                         </div>
                     </div>
             <?php
@@ -93,21 +97,23 @@
             foreach ($dados->data->results as $creators) {
                 $path = $creators->thumbnail->path;
                 $extension = $creators->thumbnail->extension;
-                $image = $path . "." . $extension;
+                $image = $path ."/portrait_incredible.". $extension;
                 $id = $creators->id;
                 $fullName = $creators->fullName;
             ?>
                 <div class="col-12 col-md-3">
-                    <div class="card text-center">
+                    <div class="card">
                         <img src="<?= $image ?>" alt="<?= $fullName ?>">
-                        <p class="titulo">
-                            <strong>
-                                <?= $fullName ?>
-                            </strong>
-                        </p>
-                        <p>
-                            <a href="creators/<?= $id ?>" class="btn btn-warning">See More</a>
-                        </p>
+                        <div class="card-body text-center">
+                            <p class="titulo">
+                                <strong>
+                                    <?= $fullName ?>
+                                </strong>
+                            </p>
+                            <p>
+                                <a href="creators/<?= $id ?>" class="btn btn-warning">See more</a>
+                            </p>
+                        </div>
                     </div>
                 </div>
                 <?php

--- a/paginas/serie.php
+++ b/paginas/serie.php
@@ -14,7 +14,7 @@
         $title = $serie->title;
         $description = $serie->description;
         $extension = $serie->thumbnail->extension;
-        $image = $path ."/portrait_incredible.". $extension;
+        $image = $path .$imageSizeUrl. $extension;
 
 ?>
     <h1 class="text-center my-5">Serie</h1>
@@ -58,7 +58,7 @@
                 foreach ($dados->data->results as $characters) {
                     $path = $characters->thumbnail->path;
                     $extension = $characters->thumbnail->extension;
-                    $image = $path ."/portrait_incredible.". $extension;
+                    $image = $path .$imageSizeUrl. $extension;
                     $name = $characters->name;
                     $id = $characters->id;
             ?>
@@ -97,7 +97,7 @@
             foreach ($dados->data->results as $creators) {
                 $path = $creators->thumbnail->path;
                 $extension = $creators->thumbnail->extension;
-                $image = $path ."/portrait_incredible.". $extension;
+                $image = $path .$imageSizeUrl. $extension;
                 $id = $creators->id;
                 $fullName = $creators->fullName;
             ?>

--- a/paginas/series.php
+++ b/paginas/series.php
@@ -10,7 +10,7 @@
             $title = $series->title;
             $path = $series->thumbnail->path;
             $extension = $series->thumbnail->extension;
-            $image = $path ."/portrait_incredible.". $extension;
+            $image = $path .$imageSizeUrl. $extension;
             ?>
                 <div class="col-12 col-md-3">
                     <div class="card">

--- a/paginas/series.php
+++ b/paginas/series.php
@@ -10,14 +10,20 @@
             $title = $series->title;
             $path = $series->thumbnail->path;
             $extension = $series->thumbnail->extension;
-            $image = $path . '.' . $extension;
+            $image = $path ."/portrait_incredible.". $extension;
             ?>
                 <div class="col-12 col-md-3">
                     <div class="card">
                         <img src="<?= $image?>" alt="<?= $title ?>">
                         <div class="card-body text-center">
-                            <p class="card-title"> <?=$title?></p>
-                            <p><a href="serie/<?=$id?>" class="btn btn-warning">See more</a></p>
+                            <p class="titulo">
+                                <strong>
+                                    <?= $title ?>
+                                </strong>
+                            </p>
+                            <p>
+                                <a href="serie/<?= $id ?>" class="btn btn-warning">See more</a>
+                            </p>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Visão geral
Esta implementação padroniza o tamanho das imagens com uma variável para ser utilizada na URL da `$image`. Também foi ajustado a altura dos títulos dos cards para um tamanho padrão que contemplasse todos os títulos (dos menores aos maiores).

## Modificações
- config-exemple.php: criação da variável `$imageSizeUrl`;
- páginas: utilização de `$imageSizeUrl` na concatenação que forma o valor de `$image`;
- style.css: ajustes das imagens no carrossel;